### PR TITLE
Fix golang 1.8 compile problems

### DIFF
--- a/client.go
+++ b/client.go
@@ -308,8 +308,8 @@ func (cl *Client) Start(mechlist []string) (mech string, response []byte,
 
 	for {
 		res = C.sasl_client_start(cl.client.sc_conn, mechlistStr,
-			unsafe.Pointer(&prompt), unsafe.Pointer(&responseStr),
-			&responseLen, unsafe.Pointer(&mechStr))
+			&prompt, &responseStr,
+			&responseLen, &mechStr)
 		if res != C.SASL_INTERACT {
 			break
 		}
@@ -342,7 +342,7 @@ func (cl *Client) Step(challenge []byte) (response []byte, done bool,
 	challengeLen := C.uint(len(challenge))
 	for {
 		res = C.sasl_client_step(cl.client.sc_conn, challengeStr, challengeLen,
-			unsafe.Pointer(prompt), &responseStr, &responseLen)
+			&prompt, &responseStr, &responseLen)
 		if res != C.SASL_INTERACT {
 			break
 		}

--- a/conn.go
+++ b/conn.go
@@ -61,7 +61,7 @@ func encode(conn *C.struct_sasl_conn, buf []byte) (out []byte, err error) {
 	input := C.CString(string(buf))
 	inputLen := C.uint(len(buf))
 
-	res := C.sasl_encode(conn, input, inputLen, unsafe.Pointer(&outputStr),
+	res := C.sasl_encode(conn, input, inputLen, &outputStr,
 		&outputLen)
 	if res != C.SASL_OK {
 		return nil, newError(conn, res, "encode")
@@ -79,7 +79,7 @@ func decode(conn *C.struct_sasl_conn, buf []byte) (out []byte,
 	input := C.CString(string(buf))
 	inputLen := C.uint(len(buf))
 
-	res := C.sasl_decode(conn, input, inputLen, unsafe.Pointer(&outputStr),
+	res := C.sasl_decode(conn, input, inputLen, &outputStr,
 		&outputLen)
 	if res != C.SASL_OK {
 		return nil, newError(conn, res, "decode")


### PR DESCRIPTION
```
client.go:311: cannot use unsafe.Pointer(&prompt) (type unsafe.Pointer) as type **C.struct_sasl_interact in argument to func literal
client.go:311: cannot use unsafe.Pointer(&responseStr) (type unsafe.Pointer) as type **C.char in argument to func literal
client.go:312: cannot use unsafe.Pointer(&mechStr) (type unsafe.Pointer) as type **C.char in argument to func literal
client.go:345: cannot use unsafe.Pointer(prompt) (type unsafe.Pointer) as type **C.struct_sasl_interact in argument to func literal
conn.go:64: cannot use unsafe.Pointer(&outputStr) (type unsafe.Pointer) as type **C.char in argument to func literal
conn.go:82: cannot use unsafe.Pointer(&outputStr) (type unsafe.Pointer) as type **C.char in argument to func literal
```